### PR TITLE
FRED-486: line item requires an id and has a default set

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ This will return the following object:
 Generates a line item with default values.
 
 - `variantName` defaults to `cover` if not set.
+- `id` defaults to a random UUID if not set.
 
 ```js
 const lineItem = KiteWebAppSdk.initaliseLineItem(
@@ -138,6 +139,7 @@ const lineItem = KiteWebAppSdk.initaliseLineItem(
         urlFull: 'image1Url',
         urlPreview: 'image1Preview',
     }],
+    'lineItemId',
     'variantName',
 );
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kite-tech/web-app-sdk",
-  "version": "0.0.1-alpha.9",
+  "version": "0.1.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kite-tech/web-app-sdk",
-  "version": "0.0.1-alpha.10",
+  "version": "0.1.0-alpha.1",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -24,6 +24,41 @@ const initKiteWebAppSdk = (
 };
 
 describe('initaliseLineItem', () => {
+    test('Sets id to the value in the argument', () => {
+        const kiteWebAppSdk = initKiteWebAppSdk();
+
+        const lineItem = kiteWebAppSdk.initaliseLineItem(
+            'templateId',
+            [{
+                urlFull: 'urlFull',
+                urlPreview: 'urlPreview',
+            }, {
+                urlFull: 'urlFull2',
+                urlPreview: 'urlPreview2',
+            }],
+            'id',
+        );
+
+        expect(lineItem.id).toBe('id');
+    });
+
+    test('Sets id to a UUID if not defined in the arguments', () => {
+        const kiteWebAppSdk = initKiteWebAppSdk();
+
+        const lineItem = kiteWebAppSdk.initaliseLineItem(
+            'templateId',
+            [{
+                urlFull: 'urlFull',
+                urlPreview: 'urlPreview',
+            }, {
+                urlFull: 'urlFull2',
+                urlPreview: 'urlPreview2',
+            }],
+        );
+
+        expect(lineItem.id).toBe(mockUUID);
+    });
+
     test('Creates the same number of images as in the imageUrls array', () => {
         const kiteWebAppSdk = initKiteWebAppSdk();
 
@@ -214,6 +249,7 @@ describe('initaliseLineItem', () => {
                 urlFull: 'urlFull2',
                 urlPreview: 'urlPreview2',
             }],
+            undefined,
             'variant',
         );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,9 +24,11 @@ export class KiteWebAppSdk {
             urlFull: string,
             urlPreview: string,
         }> = [],
+        id = UUID.UUID(),
         variantName = 'cover',
     ): LineItemInterface {
         return {
+            id,
             images: imageUrls.map(({
                 urlFull,
                 urlPreview,

--- a/src/models/posted-data/line-item.interface.ts
+++ b/src/models/posted-data/line-item.interface.ts
@@ -3,7 +3,7 @@ import {
 } from '@kite-tech/components';
 
 export interface LineItemInterface {
-    id?: string;
+    id: string;
     templateId: string;
     images?: ImageEditorImageInterface[];
     variantName?: string;


### PR DESCRIPTION
Set id of line items to required. This is needed by the wall art app to distinguish between line items.
If the user doesn't set one we add a default.