### PR TITLE
[APPS-59]: Print Shop SDK documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ KiteWebAppSdk.launchFromJSON(printShopConfig);
 | Property           | Type                                                    | Required | Description                                                             |
 |--------------------|---------------------------------------------------------|----------|-------------------------------------------------------------------------|
 | baseUrl            | string                                                  | YES      | The complete URL of your shop                                           |
-| config             | [_ConfigObject_](#ConfigObject)                         | NO       | Specify additional properties while launch                              |
+| config             | [_ConfigObject_](#ConfigObject)                         | NO       | Specify additional properties for launch                                |
 | checkoutUserFields | [_CheckoutUserFieldsObject_](#CheckoutUserFieldsObject) | NO       | User details to populate on checkout                                    |
-| collectorImages    | [_CollectorImagesArray_](#CollectorImagesArray)         | NO       | Images passed on to your shop that can be applied on different products |
+| collectorImages    | [_CollectorImagesArray_](#CollectorImagesArray)         | NO       | Images passed in to your shop that can be applied to different products |
 
 <br>
 
@@ -65,8 +65,8 @@ KiteWebAppSdk.launchFromJSON(printShopConfig);
 | Property        | Type                                                                                                                                                                                                                                            | Required | Description                                                            |
 |-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------|
 | shippingAddress | <pre> {<br>   recipient_first_name: string,<br>   recipient_last_name: string,<br>   address_line_1: string,<br>   address_line_2: string,<br>   city: string,<br>   county_state: string,<br>   postcode: string,<br>   country: string,<br> } | NO       | User shipping address to populate on checkout. All values are optional |
-| customerEmail   | string                                                                                                                                                                                                                                          | NO       | Email set for the user when they reach checkout                        |
-| termsOfService  | boolean                                                                                                                                                                                                                                         | NO       | Set to automatically agree to terms of service on checkout             |
+| customerEmail   | string                                                                                                                                                                                                                                          | NO       | Sets the user's email address when they reach the checkout            |
+| termsOfService  | boolean                                                                                                                                                                                                                                         | NO       | Sets whether to automatically agree to terms of service on checkout             |
 
 <br>
 
@@ -78,6 +78,6 @@ An array of objects having the following properties:
 |------------------|----------------------------------------------------------|----------|-----------------------------------------------------------------------|
 | dimensions       | <pre> {<br>   width: number,<br>   height: number<br> }  | YES      | The dimensions of the image URL specified                             |
 | id               | string                                                   | YES      | Unique ID for the image                                               |
-| isUploadComplete | boolean                                                  | YES      | Specify if image upload is complete                                   |
-| thumbnailUrl     | string                                                   | YES      | Lower resolution image URL used for rendering previews in the browser |
-| url              | string                                                   | YES      | Full resolution image URL used for printing                           |
+| isUploadComplete | boolean                                                  | YES      | Specify whether the image upload is complete                          |
+| thumbnailUrl     | string                                                   | YES      | Lower resolution image URL, used for rendering previews in the browser|
+| url              | string                                                   | YES      | Full resolution image URL, used for printing                          |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prodigi Print Shop SDK
 
-Compatible with the [Print on Demand Shop](https://shop.prodigi.com/) by [Prodigi](http://prodigi.com/). Get yours at [Prodigi Apps Dashboard](https://dashboard.prodigi.com/apps)
+Compatible with the [Print on Demand Shop](https://shop.prodigi.com) by [Prodigi](https://www.prodigi.com/). Get yours at [Prodigi Apps Dashboard](https://dashboard.prodigi.com/apps)
 
 The Print Shop SDK provides an API to launch your app with pre-configured data, such as images, at run-time.
 
@@ -12,7 +12,7 @@ The Print Shop SDK provides an API to launch your app with pre-configured data, 
 
 ## Demo and examples
 
-For a list of common use-cases and a demo sandbox visit: https://prodigi-sdk-test.web.app/
+For a list of common use-cases and a demo sandbox visit: https://prodigi-web-sdks.web.app/print-shop
 
 ## Installation
 
@@ -21,12 +21,6 @@ Install using NPM:
 ```
 npm install @kite-tech/web-app-sdk
 ```
-
-<!-- or import using CDN:
-
-```html
-<script src="https://unpkg.com/@kite-tech/web-app-sdk/dist/index.js"></script>
-``` -->
 
 ## Usage
 
@@ -38,7 +32,7 @@ import { KiteWebAppSdk } from '@kite-tech/web-app-sdk';
 Launch your shop using the `launchFromJSON` function and pass in your desired configuration:
 ```js
 const printShopConfig = {
-    baseUrl: 'https://shop.prodigi.com/prodigi/'
+    baseUrl: 'https://shop.prodigi.com/prodigi'
 };
 
 KiteWebAppSdk.launchFromJSON(printShopConfig);
@@ -58,10 +52,10 @@ For all configuration options, see [API](#api)
 
 ### ConfigObject
 
-|      Property | Type    | Required | Description                               |
-|---------------|---------|----------|-------------------------------------------|
-| startInNewTab | boolean | NO       | Opens your shop in a new tab/window       |
-| customer_id   | string  | NO       | Custom identifier associated to your user |
+| Property      | Type    | Required | Description                                           |
+|---------------|---------|----------|-------------------------------------------------------|
+| startInNewTab | boolean | NO       | Opens your shop in a new tab/window. Default is false |
+| customer_id   | string  | NO       | Custom identifier associated to your user             |
 
 <br>
 
@@ -81,7 +75,7 @@ An array of objects having the following properties:
 
 | Property         | Type                                                     | Required | Description                                                           |
 |------------------|----------------------------------------------------------|----------|-----------------------------------------------------------------------|
-| dimensions       | <pre> {<br>   width: number,<br>   height: number,<br> } | YES      | The dimensions of the image URL specified                             |
+| dimensions       | <pre> {<br>   width: number,<br>   height: number<br> }  | YES      | The dimensions of the image URL specified                             |
 | id               | string                                                   | YES      | Unique ID for the image                                               |
 | isUploadComplete | boolean                                                  | YES      | Specify if image upload is complete                                   |
 | thumbnailUrl     | string                                                   | YES      | Lower resolution image URL used for rendering previews in the browser |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prodigi Print Shop SDK
 
-Compatible with the [Print on Demand Shop](https://shop.prodigi.com/) by [Prodigi](http://prodigi.com/). Get yours at https://dashboard.prodigi.com/apps
+Compatible with the [Print on Demand Shop](https://shop.prodigi.com/) by [Prodigi](http://prodigi.com/). Get yours at [Prodigi Apps Dashboard](https://dashboard.prodigi.com/apps)
 
 The Print Shop SDK provides an API to launch your app with pre-configured data, such as images, at run-time.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With the Print Shop SDK, you can integrate your print shop app into your own sit
 
 ## Demo and examples
 
-For a list of common use-cases and a demo sandbox visit: [https://prodigi-web-sdks.web.app/print-shop](https://prodigi-web-sdks.web.app/print-shop)
+For a list of common use-cases and a demo sandbox visit: [https://sdk.prodigi.com/print-shop](https://sdk.prodigi.com/print-shop)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Prodigi Print Shop SDK
 
-Compatible with the [Print on Demand Shop](https://shop.prodigi.com) by [Prodigi](https://www.prodigi.com/). Get yours at [Prodigi Apps Dashboard](https://dashboard.prodigi.com/apps)
+[Prodigi](https://www.prodigi.com/) offers white label print on demand portals so you can sell to your users under your brand. 
 
-The Print Shop SDK provides an API to launch your app with pre-configured data, such as images, at run-time.
+This SDK is compatible with the Prodigi [Print on Demand Shop](https://shop.prodigi.com). Get your own branded instance at [Prodigi Apps Dashboard](https://dashboard.prodigi.com/apps).
+
+With the Print Shop SDK, you can integrate your print shop app into your own site, launching it with pre-configured data, such as images, at run-time.
 
 ## Table of Contents
 - [Demo and examples](#demo-and-examples)
@@ -37,7 +39,6 @@ const printShopConfig = {
 
 KiteWebAppSdk.launchFromJSON(printShopConfig);
 ```
-For all configuration options, see [API](#api)
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Print Shop SDK provides an API to launch your app with pre-configured data, 
 
 ## Demo and examples
 
-For a list of common use-cases and a demo sandbox visit: https://prodigi-web-sdks.web.app/print-shop
+For a list of common use-cases and a demo sandbox visit: [https://prodigi-web-sdks.web.app/print-shop](https://prodigi-web-sdks.web.app/print-shop)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
-# Kite Web App SDK
+# Prodigi Print Shop SDK
 
-The Kite Web App SDK provides an interface to launch into the Kite/Prodigi web apps.
+Compatible with the [Print on Demand Shop](https://shop.prodigi.com/) by [Prodigi](http://prodigi.com/). Get yours at https://dashboard.prodigi.com/apps
 
-Included web app:
-- Print Shop
+The Print Shop SDK provides an API to launch your app with pre-configured data, such as images, at run-time.
 
 ## Table of Contents
+- [Demo and examples](#demo-and-examples)
 - [Installation](#installation)
+- [Usage](#usage)
 - [API](#api)
+
+## Demo and examples
+
+For a list of common use-cases and a demo sandbox visit: https://prodigi-sdk-test.web.app/
 
 ## Installation
 
@@ -16,285 +21,68 @@ Install using NPM:
 ```
 npm install @kite-tech/web-app-sdk
 ```
-    
-### Import
 
-#### ES6 module
+<!-- or import using CDN:
 
+```html
+<script src="https://unpkg.com/@kite-tech/web-app-sdk/dist/index.js"></script>
+``` -->
+
+## Usage
+
+<!-- If installed using npm, import the package: -->
+Import the package:
 ```js
 import { KiteWebAppSdk } from '@kite-tech/web-app-sdk';
 ```
-
-#### Require
-
+Launch your shop using the `launchFromJSON` function and pass in your desired configuration:
 ```js
-const KiteWebAppSdk = require('@kite-tech/web-app-sdk');
+const printShopConfig = {
+    baseUrl: 'https://shop.prodigi.com/prodigi/'
+};
+
+KiteWebAppSdk.launchFromJSON(printShopConfig);
 ```
-
-### Suggested JavaScript Usage
-
-Import the script in the html or package it with your app.
-
-```html
-// From CDN
-<script src="https://unpkg.com/@kite-tech/web-app-sdk"></script>
-
-// From local node_modules
-<script src="/node_modules/@kite-tech/web-app-sdk"></script>
-```
+For all configuration options, see [API](#api)
 
 ## API
 
-### Launch with Items
+| Property           | Type                                                    | Required | Description                                                             |
+|--------------------|---------------------------------------------------------|----------|-------------------------------------------------------------------------|
+| baseUrl            | string                                                  | YES      | The complete URL of your shop                                           |
+| config             | [_ConfigObject_](#ConfigObject)                         | NO       | Specify additional properties while launch                              |
+| checkoutUserFields | [_CheckoutUserFieldsObject_](#CheckoutUserFieldsObject) | NO       | User details to populate on checkout                                    |
+| collectorImages    | [_CollectorImagesArray_](#CollectorImagesArray)         | NO       | Images passed on to your shop that can be applied on different products |
 
-Launches an app with some images in the user's image collector, some existing
-line items or both.
+<br>
 
-It may be useful to use the `KiteWebAppSdk.initaliseLineItem` or
-the `KiteWebAppSdk.initialiseCollectorImage` to create the line items or the
-collector images with default values.
+### ConfigObject
 
-```js
-KiteWebAppSdk.launchWithItemsAndImages({
-    baseUrl: 'https://shop.prodigi.com/prodigi/',
-    collectorImages: [{
-        dimensions: {
-            width: 100,
-            height: 150,   
-        },
-        id: 'imageId',
-        isUploadComplete: true,
-        thumbnailUrl: 'imageThumbnailUrl',
-        url: 'imageUrl',
-    }],
-    lineItems: [{
-        designId?: string
-        images: [{
-            filters: null,
-            mirror: false,
-            rotate_degrees: 0,
-            scale: 1,
-            aspect?: 'fit', // Optional Property to aspect fit the image inside specified template
-            tx: 0,
-            ty: 0,
-            url_full: 'image1Url',
-            url_preview: 'image1Preview'
-        }],
-        affiliate_id: 'affiliateId',
-        templateId: 'kiteTemplateId',
-        variantName: 'variantName',
-    }],
-});
-```
+|      Property | Type    | Required | Description                               |
+|---------------|---------|----------|-------------------------------------------|
+| startInNewTab | boolean | NO       | Opens your shop in a new tab/window       |
+| customer_id   | string  | NO       | Custom identifier associated to your user |
 
-Other [options](#options) are available.
+<br>
 
-### Intialise Methods
+### CheckoutUserFieldsObject
 
-#### Initialise Collector Image
+| Property        | Type                                                                                                                                                                                                                                            | Required | Description                                                            |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------|
+| shippingAddress | <pre> {<br>   recipient_first_name: string,<br>   recipient_last_name: string,<br>   address_line_1: string,<br>   address_line_2: string,<br>   city: string,<br>   county_state: string,<br>   postcode: string,<br>   country: string,<br> } | NO       | User shipping address to populate on checkout. All values are optional |
+| customerEmail   | string                                                                                                                                                                                                                                          | NO       | Email set for the user when they reach checkout                        |
+| termsOfService  | boolean                                                                                                                                                                                                                                         | NO       | Set to automatically agree to terms of service on checkout             |
 
-Generates a collector image with default values.
+<br>
 
-- `id` will default to a random GUID
+### CollectorImagesArray
 
-```js
-const collectorImage = KiteWebAppSdk.initialiseCollectorImage(
-    'imageUrl',
-    'imageThumbnailUrl',
-    {
-        width: 100,
-        height: 150,   
-    },
-    'imageId'
-);
-```
+An array of objects having the following properties:
 
-This will return the following object:
-```js
-{
-    dimensions: {
-        width: 100,
-        height: 150,   
-    },
-    id: 'imageId',
-    isUploadComplete: true,
-    thumbnailUrl: 'imageThumbnailUrl',
-    url: 'imageUrl',
-}
-```
-
-#### Initialise Line Item
-
-Generates a line item with default values.
-
-- `variantName` defaults to `cover` if not set.
-- `id` defaults to a random UUID if not set.
-
-```js
-const lineItem = KiteWebAppSdk.initaliseLineItem(
-    'kiteTemplateId',
-    [{
-        urlFull: 'image1Url',
-        urlPreview: 'image1Preview',
-    }],
-    'lineItemId',
-    'variantName',
-);
-```
-
-This will return the following object:
-
-```js
-{
-    images: [
-        filters: null,
-        mirror: false,
-        rotate_degrees: 0,
-        scale: 1,
-        tx: 0,
-        ty: 0,
-        url_full: 'image1Url',
-        url_preview: 'image1Preview'
-    ],
-    templateId: 'kiteTemplateId',
-    variantName: 'variantName',
-}
-```
-
-### Launch from JSON
-
-Launches the app from the state JSON for loading a stored user state.
-
-```js
-KiteWebAppSdk.launchFromJSON({
-    appStateJSONString: JSON.stringify({
-        appState: 'exampleState'
-    }),
-    baseUrl: 'http://dev-wall-art.kite.ly/canon/'
-});
-```
-
-Other [options](#options) are available.
-
-### Options
-
-These other options can be used both for the `launchFromJSON` and the
-`launchWithItemsAndImages` functions.
-
-- All of these except `baseUrl` are optional.
-
-- By default, user uploads _are enabled_ and the associated interface controls made visible. This functionality can be set manually either in the Angular module for a partner's app (`brandSettings.featureSettings.userUploadsAllowed`) or through the SDK (`config.userUploadsAllowed`). Note that any user uploads setting defined via the SDK will override the corresponding setting, if set, in the partner's app module file.
-
-```typescript
-{
-    baseUrl: string,
-    brandSettings?: {
-        brandColor?: string; // Color to be used on the checkout
-        brandName?: string; // Brand name to get branch info
-        checkoutLogoImage?: string; // Logo Image used on checkout
-        checkoutLogoLinkUrl?: string; // Logo link for logo image on checkout
-        mixpanelToken: string; // Mixpanel token to use for tracking
-        publishableKey: string; // Kite partner public key
-        testPublishableKey: string; // Kite partner public key for testing
-        universalAnalyticsToken?: string; // GA Token for tracking
-        userUploadsAllowed?: boolean; // Set whether the user can upload own images.
-    },
-    breadCrumbs?: [{ // If present adds breadcrumbs separated by chevrons
-        text: string, // Bread crumb text to display
-        url?: string, // URL to redirect to if text is clicked
-        target?: string // URL href target, for example '_blank' for new tab and '_self': for current window
-    }],
-    config?: {
-        startInNewTab?: boolean; // Set to `true` to have UI open in new tab.
-        returnToUrl?: string; // If set, UI will display a button to enable users to return to the URL specified. Suitable for partners wishing to have users able to return to their own websites.
-        userUploadsAllowed?: boolean; // Set whether users can upload photos.
-        customer_id?: string;
-    },
-    checkout?: {
-        checkoutUrl?: string; // Url of the checkout to call
-        cancelCallbackUrls?: Array<{
-            // Array of urls and methods that gets called when the user presses
-            // cancel on the checkout
-            method?: string;
-            url?: string;
-        }>;
-        successCallbackUrls?: Array<{
-            // Array of urls and methods that gets called when the user makes
-            // a successful purchase
-            method?: string;
-            url?: string;
-        }>;
-        // User gets redirected to this URL when completing the checkout
-        successRedirectUrl?: string;
-    },
-    checkoutUserFields?: {
-        shippingAddress?: {
-            // Prepopulated details when the user gets to the checkout
-            recipient_first_name?: string;
-            recipient_last_name?: string;
-            address_line_1?: string;
-            address_line_2?: string;
-            city?: string;
-            county_state?: string;
-            postcode?: string;
-            country?: string;   
-        };
-        // Email set for the user when they reach the checkout
-        customerEmail?: string;
-        // Set to automatically opt the user in for marketting
-        termsOfService?: boolean;   
-    },
-    collectorImages?: [{ // Array of objects containing images that can be loaded onto products
-        dimensions: {
-            width: number,
-            height: number,   
-        },
-        id: string,
-        isUploadComplete: boolean,
-        thumbnailUrl: string,
-        url: string,
-    }],
-    lineItems?: [{ // Array of objects defining images and variants of products to be added to basket on launch
-        designId?: string
-        images: [{
-            filters: string,
-            mirror: boolean,
-            rotate_degrees: number,
-            scale: number,
-            aspect?: string, // Optional Property to aspect fit the image inside specified template
-            tx: number,
-            ty: number,
-            url_full: string,
-            url_preview: string
-        }],
-        id: string,
-        affiliate_id?: string,
-        templateId: string,
-        variantName: string,
-        options?: {
-            color: string 
-        }
-    }],
-     // Reference Id for the customers order. Used by things like the checkout
-     // callbacks to inform which user it is.
-    referenceId?: string,
-    // Custom content to include in the footer. Allows for an array of
-    // links.
-    footer?: {
-        links?: [
-            {
-                // Text for link if no translations provided.
-                defaultText: string;
-                // `language_code` is the two letter ISO 639-1 code for the language.
-                // E.g., `en` for English.
-                translations?: {
-                    [language_code: string]: [text: string]
-                },
-                url: string;
-                // Set `newFrame` to `true` to open URL in new window/tab.
-                newFrame: boolean;              
-            }
-        ]
-    }
-}
-```
+| Property         | Type                                                     | Required | Description                                                           |
+|------------------|----------------------------------------------------------|----------|-----------------------------------------------------------------------|
+| dimensions       | <pre> {<br>   width: number,<br>   height: number,<br> } | YES      | The dimensions of the image URL specified                             |
+| id               | string                                                   | YES      | Unique ID for the image                                               |
+| isUploadComplete | boolean                                                  | YES      | Specify if image upload is complete                                   |
+| thumbnailUrl     | string                                                   | YES      | Lower resolution image URL used for rendering previews in the browser |
+| url              | string                                                   | YES      | Full resolution image URL used for printing                           |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@kite-tech/web-app-sdk",
   "version": "2.0.0",
-  "description": "",
+  "description": "Prodigi print on demand shop SDK",
+  "homepage": "https://prodigi-web-sdks.web.app/print-shop",
   "main": "./dist/index.js",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -75,5 +75,11 @@
       "/node_modules/",
       "/example/"
     ]
-  }
+  },
+  "keywords": [
+    "print on demand",
+    "prodigi",
+    "print shop",
+    "sdk"
+  ]
 }


### PR DESCRIPTION
Changes:
- Updated README displayed on the npm package page - https://www.npmjs.com/package/@kite-tech/web-app-sdk. View the new one at - https://github.com/Prodigi-Group/kite-web-app-sdk/blob/APPS-59/documentation-update/README.md
- Examples and sandbox app available at https://prodigi-web-sdks.web.app/print-shop (Has a dark mode based on OS preference). This is currently deployed on Firebase. If needed can add a *.prodigi.com domain to it. Firebase hosting has a generous free tier - https://firebase.google.com/pricing. Can consider a different one if required or once we get close to hitting the paid tier. 
- Updated package.json with `description`, `homepage` and `keywords` properties which make the package better searchable on npm